### PR TITLE
Ensure creative tick before adventure in cam mode

### DIFF
--- a/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
@@ -150,9 +150,17 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         boolean originalAllowFlight = player.getAllowFlight();
         boolean originalFlying = player.isFlying();
 
-        player.setGameMode(GameMode.ADVENTURE);
-        player.setAllowFlight(true);
-        player.setFlying(true);
+        player.setGameMode(GameMode.CREATIVE);
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (cameraPlayers.containsKey(player.getUniqueId())) {
+                    player.setGameMode(GameMode.ADVENTURE);
+                    player.setAllowFlight(true);
+                    player.setFlying(true);
+                }
+            }
+        }.runTaskLater(this, 1L);
         player.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 0, false, false));
         player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, Integer.MAX_VALUE, 0, false, false));
 


### PR DESCRIPTION
## Summary
- briefly set players to creative mode for one tick when entering camera mode
- switch them back to adventure mode after the tick

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865bd7f2b948322ba7a34ead597a1fa