### PR TITLE
Ensure creative tick before adventure in cam mode

### DIFF
--- a/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
@@ -150,9 +150,19 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         boolean originalAllowFlight = player.getAllowFlight();
         boolean originalFlying = player.isFlying();
 
-        player.setGameMode(GameMode.ADVENTURE);
+        player.setGameMode(GameMode.CREATIVE);
         player.setAllowFlight(true);
         player.setFlying(true);
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (cameraPlayers.containsKey(player.getUniqueId())) {
+                    player.setGameMode(GameMode.ADVENTURE);
+                    player.setAllowFlight(true);
+                    player.setFlying(true);
+                }
+            }
+        }.runTaskLater(this, 1L);
         player.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 0, false, false));
         player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, Integer.MAX_VALUE, 0, false, false));
 


### PR DESCRIPTION
## Summary
- keep player in creative mode for one tick when entering camera mode
- apply flight settings immediately and preserve them when switching to adventure

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865bd7f2b948322ba7a34ead597a1fa