### PR TITLE
Implement custom command executor and tab completer

### DIFF
--- a/src/main/java/de/elia/cameraplugin/cameraPlugin/CamCommand.java
+++ b/src/main/java/de/elia/cameraplugin/cameraPlugin/CamCommand.java
@@ -1,0 +1,48 @@
+package de.elia.cameraplugin.cameraPlugin;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class CamCommand implements CommandExecutor {
+
+    private final CameraPlugin plugin;
+
+    public CamCommand(CameraPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.getMessage("no-player"));
+            return true;
+        }
+
+        if (!player.hasPermission("camplugin.use")) {
+            player.sendMessage(plugin.getMessage("no-permission"));
+            return true;
+        }
+
+        if (args.length > 0 && args[0].equalsIgnoreCase("reload")) {
+            if (!player.isOp()) {
+                player.sendMessage(plugin.getMessage("no-permission"));
+                return true;
+            }
+            player.sendMessage(plugin.getMessage("reload-start"));
+            plugin.reloadPlugin(player);
+            player.sendMessage(plugin.getMessage("reload-success"));
+            return true;
+        }
+
+        if (plugin.isInCameraMode(player)) {
+            plugin.exitCameraMode(player);
+            player.sendMessage(plugin.getMessage("camera-off"));
+        } else {
+            plugin.enterCameraMode(player);
+            player.sendMessage(plugin.getMessage("camera-on"));
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/elia/cameraplugin/cameraPlugin/CamTabCompleter.java
+++ b/src/main/java/de/elia/cameraplugin/cameraPlugin/CamTabCompleter.java
@@ -1,0 +1,27 @@
+package de.elia.cameraplugin.cameraPlugin;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CamTabCompleter implements TabCompleter {
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1 && sender instanceof Player && sender.isOp()) {
+            String partial = args[0].toLowerCase();
+            if ("reload".startsWith(partial)) {
+                List<String> completions = new ArrayList<>();
+                completions.add("reload");
+                return completions;
+            }
+            return Collections.emptyList();
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,6 +10,7 @@ commands:
     description: Aktiviert oder deaktiviert den Kamera-Modus
     usage: /cam
     permission: camplugin.use
+    permission-message: "Du hast keine Berechtigung für diesen Command!"
 
 permissions:
   camplugin.use:


### PR DESCRIPTION
## Summary
- add a `CamCommand` executor
- add a `CamTabCompleter`
- register new command handler in `CameraPlugin`
- expose helpers for command logic
- update `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686986d87ad88322b6583c1c8488732a