### PR TITLE
Add armor stand movement security

### DIFF
--- a/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
@@ -223,10 +223,18 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
     }
 
     private void startArmorStandHealthCheck(Player player, ArmorStand armorStand) {
+        final Location initialLocation = armorStand.getLocation().clone();
         new BukkitRunnable() {
             @Override
             public void run() {
                 if (!cameraPlayers.containsKey(player.getUniqueId()) || !player.isOnline() || armorStand.isDead()) {
+                    this.cancel();
+                    return;
+                }
+                if (!armorStand.getLocation().getWorld().equals(initialLocation.getWorld()) ||
+                        armorStand.getLocation().distanceSquared(initialLocation) > 0.01) {
+                    player.sendMessage(getMessage("body-moved"));
+                    exitCameraMode(player);
                     this.cancel();
                     return;
                 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,7 @@ messages:
   body-env-damage: "&cDein Körper wurde durch Umweltschaden verletzt! Kamera-Modus beendet."
   body-suffocating: "&cDein Körper erstickt! Kamera-Modus wird beendet."
   body-drowning: "&cDein Körper ertrinkt!"
+  body-moved: "&cDein Körper wurde bewegt! Kamera-Modus beendet."
   cant-fly-in-lava: "&cDu kannst nicht durch Lava fliegen! Kamera-Modus wird beendet."
   no-projectiles: "&cDu kannst im Kamera-Modus keine Projektile verwenden."
   cant-manipulate-other: "&cDu kannst den Körper eines anderen Spielers nicht manipulieren!"


### PR DESCRIPTION
## Summary
- introduce `body-moved` message
- exit camera mode if the armor stand changes position

## Testing
- `mvn package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68698ede34b48322b6df1684523cd82d