### PR TITLE
Fix armor stand breaking in camera mode

### DIFF
--- a/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
@@ -557,8 +557,25 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
 
     @EventHandler
     public void onPlayerAttack(EntityDamageByEntityEvent event) {
-        if (event.getDamager() instanceof Player &&
-                cameraPlayers.containsKey(event.getDamager().getUniqueId())) {
+        if (!(event.getDamager() instanceof Player attacker)) {
+            return;
+        }
+
+        if (!cameraPlayers.containsKey(attacker.getUniqueId())) {
+            return;
+        }
+
+        Entity target = event.getEntity();
+        UUID ownerUUID = null;
+
+        if (target instanceof ArmorStand) {
+            ownerUUID = armorStandOwners.get(target.getUniqueId());
+        } else if (target instanceof Villager) {
+            ownerUUID = hitboxEntities.get(target.getUniqueId());
+        }
+
+        // Cancel attacks on anything except the player's own armor stand or hitbox
+        if (ownerUUID == null || !ownerUUID.equals(attacker.getUniqueId())) {
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
## Summary
- allow camera mode players to damage their own armor stand

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9333d564832296465b8e690b5013