### PR TITLE
Remove health loss when starting camera mode

### DIFF
--- a/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
@@ -187,7 +187,6 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         armorStandOwners.put(armorStand.getUniqueId(), player.getUniqueId());
         hitboxEntities.put(hitbox.getUniqueId(), player.getUniqueId());
 
-        applyDirectDamage(player, drowningDamage);
         startHitboxSync(armorStand, hitbox);
         addPlayerToNoCollisionTeam(player);
     }


### PR DESCRIPTION
## Summary
- prevent players from taking damage when entering camera mode

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a95f549b083229f2271cea10e8248