### PR TITLE
Add visibility settings for camera mode

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,8 @@ camera-mode:
   max-distance: 100.0
   distance-warning-cooldown: 3
   drowning-damage: 2.0
+  player_visibility_mode: "cam"
+  allow_invisibility_potion: true
 
 armorstand.name-visible: true
 armorstand.visible: true


### PR DESCRIPTION
## Summary
- add `player_visibility_mode` and `allow_invisibility_potion` settings
- update CameraPlugin to respect these options and manage visibility
- ensure invisibility potion always applied when enabled
- ensure ghost mode works when all players should see invisible cam players

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686aac95da588322baabdf8d59193bf9