### PR TITLE
Implement enchantment-aware damage

### DIFF
--- a/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java
@@ -20,6 +20,8 @@ import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.ChatColor;
 import org.bukkit.potion.PotionEffect;
@@ -381,8 +383,11 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         double originalDamage = event.getDamage();
         ArmorStand armorStand = cameraPlayers.get(ownerUUID).getArmorStand();
 
-        // Schaden basierend auf der Rüstung des ArmorStands neu berechnen
-        double reducedDamage = calculateArmorReducedDamage(originalDamage, armorStand);
+        // Haltbarkeit der getragenen Rüstung verringern
+        applyArmorDurabilityLoss(armorStand);
+
+        // Schaden unter Berücksichtigung der Rüstung und ihrer Verzauberungen berechnen
+        double reducedDamage = calculateFinalDamage(event, armorStand);
 
         // Name des Angreifers bestimmen
         String damagerName = "Umgebung";
@@ -718,6 +723,82 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         double damageAfterToughness = originalDamage * (1 - Math.min(20.0,
                 Math.max(armorPoints / 5.0, armorPoints - originalDamage / (2.0 + toughness / 4.0))) / 25.0);
         return Math.max(0, damageAfterToughness);
+    }
+
+    /**
+     * Berechnet den finalen Schaden unter Berücksichtigung von Rüstung,
+     * Zähigkeit und allen relevanten Schutzverzauberungen.
+     */
+    private double calculateFinalDamage(EntityDamageEvent baseEvent, ArmorStand armorStand) {
+        double damageAfterArmor = calculateArmorReducedDamage(baseEvent.getDamage(), armorStand);
+
+        int epf = 0;
+        DamageCause cause = baseEvent.getCause();
+
+        for (ItemStack item : armorStand.getEquipment().getArmorContents()) {
+            if (item == null) continue;
+            epf += getEnchantmentProtectionFactor(item, cause);
+        }
+
+        double enchantmentReduction = Math.min(20, epf) / 25.0;
+        return damageAfterArmor * (1.0 - enchantmentReduction);
+    }
+
+    private int getEnchantmentProtectionFactor(ItemStack item, DamageCause cause) {
+        int epf = 0;
+        if (item.getEnchantments().isEmpty()) return epf;
+
+        int level;
+
+        level = item.getEnchantmentLevel(Enchantment.PROTECTION_ENVIRONMENTAL);
+        if (level > 0) epf += level;
+
+        level = item.getEnchantmentLevel(Enchantment.PROTECTION_FIRE);
+        if (level > 0 && (cause == DamageCause.LAVA || cause == DamageCause.FIRE || cause == DamageCause.HOT_FLOOR || cause == DamageCause.FIRE_TICK)) {
+            epf += level * 2;
+        }
+
+        level = item.getEnchantmentLevel(Enchantment.PROTECTION_EXPLOSIONS);
+        if (level > 0 && (cause == DamageCause.ENTITY_EXPLOSION || cause == DamageCause.BLOCK_EXPLOSION)) {
+            epf += level * 2;
+        }
+
+        level = item.getEnchantmentLevel(Enchantment.PROTECTION_PROJECTILE);
+        if (level > 0 && cause == DamageCause.PROJECTILE) {
+            epf += level * 2;
+        }
+
+        level = item.getEnchantmentLevel(Enchantment.PROTECTION_FALL);
+        if (level > 0 && cause == DamageCause.FALL) {
+            epf += level * 3;
+        }
+
+        return epf;
+    }
+
+    /**
+     * Wendet Haltbarkeitsschaden auf die Rüstung an und berücksichtigt dabei
+     * die Unbreaking-Verzauberung.
+     */
+    private void applyArmorDurabilityLoss(ArmorStand stand) {
+        for (ItemStack item : stand.getEquipment().getArmorContents()) {
+            if (item == null) continue;
+            ItemMeta meta = item.getItemMeta();
+            if (!(meta instanceof Damageable damageable)) continue;
+
+            int unbreaking = item.getEnchantmentLevel(Enchantment.DURABILITY);
+            double chanceNoDamage = switch (unbreaking) {
+                case 0 -> 0.0;
+                case 1 -> 0.5;
+                case 2 -> 2.0 / 3.0;
+                default -> 0.75; // Level 3 or higher
+            };
+
+            if (Math.random() >= chanceNoDamage) {
+                damageable.setDamage(damageable.getDamage() + 1);
+                item.setItemMeta(damageable);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- reduce armor durability for Unbreaking when the armor stand is hit
- account for protection enchantments when calculating damage
- add helper method to gather EPF and compute final damage

## Testing
- `javac src/main/java/de/elia/cameraplugin/cameraPlugin/CameraPlugin.java` *(fails: package org.bukkit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_686b08aa52748322949e95f4b3295630